### PR TITLE
Fix to the MEDS offset issue

### DIFF
--- a/Medsmaker/superbit/medsmaker_mocks.py
+++ b/Medsmaker/superbit/medsmaker_mocks.py
@@ -512,6 +512,13 @@ class BITMeasurement():
             image_info[i]['weight_ext'] = 0
             image_info[i]['bmask_path'] = self.mask_file
             image_info[i]['bmask_ext'] = 0
+
+            # The default is for 0 offset between the internal numpy arrays
+            # and the images, but we use the FITS standard of a (1,1) origin.
+            # In principle we could probably set this automatically by checking
+            # the images
+            image_info[i]['position_offset'] = 1
+
             i+=1
 
         return image_info


### PR DESCRIPTION
The `meds.util.get_meds_input_struct()` call [here](https://github.com/superbit-collaboration/superbit-metacal/blob/ee5cd3b34fb3de2e93917bc1c3d594d3c3e3bb18/Medsmaker/superbit/medsmaker_mocks.py#L532) sets a basic, default input info structure for the MEDS file. However, the default is for the `position_offset` between the FITS images and the MEDS numpy arrays to be 0. That is not the case for the FITS (1,1) origin convention, so this variable is now set correctly to be 1. Fixes the offset and #17!

A recent MEDS file run:
![image](https://user-images.githubusercontent.com/8742179/127220630-66717192-a40c-4311-b2b5-1854255db34b.png)
