### PR TITLE
Implement batch parallelization using `multiprocessing` for mock generation

### DIFF
--- a/superbit_lensing/galsim/mock_superBIT_data.py
+++ b/superbit_lensing/galsim/mock_superBIT_data.py
@@ -110,7 +110,6 @@ def make_obj_runner(batch_indices, *args, **kwargs):
     Handles the batch running of make_obj() over multiple cores
     '''
 
-    # return make_obj(i, obj_type, *args, **kwargs)
     res = []
     for i in batch_indices:
         res.append(make_obj(i, *args, **kwargs))

--- a/superbit_lensing/utils.py
+++ b/superbit_lensing/utils.py
@@ -255,6 +255,25 @@ def ngmix_dict2table(d):
 
     return Table(data=d)
 
+def setup_batches(nobjs, ncores):
+    '''
+    Create list of batch indices for each core
+    '''
+
+    batch_len = [nobjs//ncores]*(ncores-1)
+
+    s = int(np.sum(batch_len))
+    batch_len.append(nobjs-s)
+
+    batch_indices = []
+
+    start = 0
+    for i in range(ncores):
+        batch_indices.append(range(start, start + batch_len[i]))
+        start += batch_len[i]
+
+    return batch_indices
+
 def make_dir(d):
     '''
     Makes dir if it does not already exist


### PR DESCRIPTION
As the title says. @mcclearyj having MPI issues on the Brown cluster (who doesn't), so this allows us to run using the builtin `multiprocessing` module. Still uses batch parallelization, and we can now allocate a bunch of cores on a node to each cluster or exposure without worrying about MPI.