### PR TITLE
finish implementation of annular selection in configs

### DIFF
--- a/superbit_lensing/shear_profiles/annular_jmac.py
+++ b/superbit_lensing/shear_profiles/annular_jmac.py
@@ -189,7 +189,7 @@ class Annular(object):
             'y': self.y,
             'g1': self.g1,
             'g2': self.g2
-            }
+        }
 
         xc = self.annular_info['coadd_center'][0]
         yc = self.annular_info['coadd_center'][1]
@@ -207,12 +207,12 @@ class Annular(object):
         newtab.add_columns(
             [x, y, self.r, self.gtan, self.gcross, self.weight],
             names=['x', 'y', 'r', 'gtan', 'gcross', 'weight']
-            )
+        )
 
         run_name = self.run_name
         outfile = os.path.join(
             outdir, f'{run_name}_transformed_shear_tab.fits'
-            )
+        )
         newtab.write(outfile, format='fits', overwrite=overwrite)
 
         return
@@ -234,15 +234,15 @@ class Annular(object):
             # Resample so redshift distribution matches input galaxies
             nfw_tab = self._nfw_resample_redshift(
                 Nresample, outdir=outdir, overwrite=overwrite,
-                )
+            )
 
             # Calculate tangential and cross shears for nfw
             self._nfw_transform_shear(nfw_tab)
 
             nfw_tab.write(
-                os.path.join(
-                    outdir,'subsampled_nfw_cat.fits'), format='fits', overwrite=overwrite
-                )
+                os.path.join(outdir,'subsampled_nfw_cat.fits'),
+                format='fits', overwrite=overwrite
+            )
 
         else:
             # No NFW file passed, return None
@@ -280,10 +280,10 @@ class Annular(object):
 
         n_selec, bin_edges = np.histogram(
             self.z, bins=100, range=[self.z.min(),self.z.max()]
-            )
+        )
         n_nfw, bin_edges_nfw = np.histogram(
             pseudo_nfw['redshift'], bins=100, range=[self.z.min(),self.z.max()]
-            )
+        )
 
         pseudo_prob = n_selec / n_nfw
         domain = np.arange(self.z.min(), self.z.max(), 0.0001)
@@ -297,7 +297,7 @@ class Annular(object):
             this_bin = np.digitize(this_z, bin_edges_nfw)
 
             odds = rng.random()
-            if (this_bin<len(n_selec)) and (odds <= pseudo_prob[this_bin-1]):
+            if (this_bin < len(n_selec)) and (odds <= pseudo_prob[this_bin-1]):
                 subsampled_redshifts.append(this_z)
                 t.append(nfw[i].as_void())
             else:
@@ -309,10 +309,17 @@ class Annular(object):
         # This should be in diagnostics, but do it here for now
         fig, ax = plt.subplots(1, 1, figsize=(8, 6))
 
-        ax.hist(nfw_tab['redshift'],bins=100,range=[self.z.min(),\
-                                                    self.z.max()],histtype='step',label='nfw resamp', density=True)
-        ax.hist(self.z,bins=100,range=[self.z.min(),\
-                                       self.z.max()],histtype='step',label='selected galaxies', density=True)
+        ax.hist(
+            nfw_tab['redshift'], bins=100,
+            range=[self.z.min(), self.z.max()], histtype='step',
+            label='nfw resamp', density=True
+        )
+        ax.hist(
+            self.z, bins=100,
+            range=[self.z.min(), self.z.max()],
+            histtype='step',label='selected galaxies', density=True
+        )
+
         ax.set_xlabel('Galaxy redshift')
         ax.set_ylabel('Number')
         ax.legend()
@@ -333,7 +340,7 @@ class Annular(object):
             'y': nfw_tab[self.nfw_info['xy_args'][1]],
             'g1': nfw_tab[self.nfw_info['shear_args'][0]],
             'g2': nfw_tab[self.nfw_info['shear_args'][1]]
-            }
+        }
 
         shears = ShearCalc(inputs = shear_inputs)
         shears.get_r_gtan(xc=xc, yc=yc)
@@ -355,8 +362,8 @@ class Annular(object):
 
     def compute_profile(self, outfile, nfw_tab=None, overwrite=False):
         '''
-        Computes mean tangential and cross shear of background (redshift-filtered)
-        galaxies in azimuthal bins
+        Computes mean tangential and cross shear of background
+        (redshift-filtered) galaxies in azimuthal bins
         '''
 
         minrad = self.annular_info['rmin']
@@ -415,12 +422,12 @@ class Annular(object):
         # otherwise return None
         nfw_tab = self.process_nfw(
             Nresample, outdir=outdir, overwrite=overwrite
-            )
+        )
 
         # Compute azimuthally averaged shear profiles
         profile_tab = self.compute_profile(
             outfile, nfw_tab=nfw_tab, overwrite=overwrite
-            )
+        )
 
         # Plot results
         self.plot_profile(profile_tab, plotfile, nfw_tab=nfw_tab)
@@ -478,7 +485,8 @@ def _compute_profile(shear_tab, rbins, nfw_tab=None):
     table.add_columns(
         [counts, midpoint_r, gtan_mean, gcross_mean, gtan_err, gcross_err],
         names=[
-            'counts', 'midpoint_r', 'mean_gtan', 'mean_gcross', 'err_gtan', 'err_gcross'
+            'counts', 'midpoint_r', 'mean_gtan',
+            'mean_gcross', 'err_gtan', 'err_gcross'
         ],
     )
 

--- a/superbit_lensing/shear_profiles/configs/default_annular_config.yaml
+++ b/superbit_lensing/shear_profiles/configs/default_annular_config.yaml
@@ -1,0 +1,49 @@
+################################################################################
+#                            CONFIGURATION FILE                               #
+################################################################################
+
+# Description:
+# This configuration file allows you to customize the lensing (metacal)
+# selection cuts for make_annular_catalog.py.
+
+# Note:
+# - Do not change the variable names (the text before the colon).
+# - Only modify the values on the right side of the colon.
+
+# Metacal-specific selection cuts:
+# Note:
+# - "T" parametrizes object size as an area in arcsec^2
+# - Photometric quanties from SExtractor are also included
+# -----------------
+mcal_cuts:
+  # Minimum ratio of galaxy size relative to PSF size
+  min_Tpsf: 0.5
+  # Maximum galaxy SNR
+  max_sn: 1000
+  # Minimum galaxy SNR
+  min_sn: 7
+  # Minimum galaxy size
+  min_T: 0.0
+  # Maximum galaxy size
+  max_T: 100
+  # How faint of aperture mag to keep; helps cut out junk
+  max_mag_aper: 99
+  # How faint of MAG_AUTO to keep; helps cut out junk
+  max_mag_auto: 99
+  # Maximum SEXtractor flag value allowed
+  max_sex_flags: 1
+
+# Miscellaneous parameters:
+# -------------------------
+# Galaxy shape noise for calculating weights
+shape_noise: 0.3
+# Denominator for responsivity calculation
+mcal_shear: 0.01
+
+# Boolean Flags:
+# --------------
+# Flag1: Description of Flag1. (e.g., Flag1 = TRUE)
+# Flag2: Description of Flag2. (e.g., Flag2 = FALSE)
+
+
+################################################################################

--- a/superbit_lensing/shear_profiles/make_redshift_cat.py
+++ b/superbit_lensing/shear_profiles/make_redshift_cat.py
@@ -62,3 +62,4 @@ def make_redshift_catalog(datadir, target, band, detect_cat_path):
     new_table.write(new_table_path, format='fits', overwrite=True)
 
     print(f"Saved a redshift catalog to {new_table_path}")
+    return new_table_path


### PR DESCRIPTION
In the `shear-profiles` module, rather than having hard-coded lensing catalog selections, pass a configuration file (`superbit_lensing/shear_profiles/configs/default_annular_config.yaml`) with reasonable values that can be adapted for different clusters if need be. 

Somewhat related: there has been some back-and-forth regarding where to collect assorted`galsim` and `medsmaker`-specific configuration files, but for now, I think we are keeping them in sub-directories called `config` within the appropriate module directory. As such, the location of configs for `superbit_lensing/shear_profiles/make_annular_catalog.py` follows our current convention. 